### PR TITLE
Add Krossbow to the libraries list

### DIFF
--- a/libraries.json
+++ b/libraries.json
@@ -985,6 +985,11 @@
     "maven": "https://repo1.maven.org/maven2/io/github/amuzanl/kotlin/FlowValve/"
   },
   {
+    "github": "joffrey-bion/krossbow",
+    "category": "Network",
+    "maven": "https://repo1.maven.org/maven2/org/hildan/krossbow/krossbow-stomp-core/"
+  },
+  {
     "github": "rickclephas/KMP-NativeCoroutines",
     "category": "Async",
     "maven": "https://repo1.maven.org/maven2/com/rickclephas/kmp/kmp-nativecoroutines-core/"


### PR DESCRIPTION
This follows a suggestion from @Romixery to make Krossbow discoverable through KAMP.
https://github.com/joffrey-bion/krossbow/issues/190

The lib is not added to the end of the list in order to avoid conflicts with another open pull-request that appends something new at the end of the JSON. Maybe this could be avoided in the future if the JSON is sorted in some way (e.g. alphabetically).