### PR TITLE
Add KtProvider

### DIFF
--- a/libraries.json
+++ b/libraries.json
@@ -1163,5 +1163,10 @@
     "github": "jeffdgr8/kotbase",
     "category": "Storage",
     "maven": "https://repo1.maven.org/maven2/dev/kotbase/couchbase-lite/"
+  },
+  {
+    "github": "985892345/KtProvider",
+    "category": "SPI",
+    "maven": "https://s01.oss.sonatype.org/content/repositories/releases/io/github/985892345/provider-api/"
   }
 ]

--- a/libraries.json
+++ b/libraries.json
@@ -1167,6 +1167,6 @@
   {
     "github": "985892345/KtProvider",
     "category": "SPI",
-    "maven": "https://s01.oss.sonatype.org/content/repositories/releases/io/github/985892345/provider-api/"
+    "maven": "https://repo1.maven.org/maven2/io/github/985892345/provider-api/"
   }
 ]


### PR DESCRIPTION
About Cross-module service providing framework for Kotlin Multiplatform Project (KMP) support.

https://github.com/985892345/KtProvider