### PR TITLE
Point to Kable's new Maven coordinates

### DIFF
--- a/libraries.json
+++ b/libraries.json
@@ -847,7 +847,7 @@
   {
     "github": "JuulLabs/kable",
     "category": "Bluetooth",
-    "maven": "https://repo1.maven.org/maven2/com/juul/kable/core/"
+    "maven": "https://repo1.maven.org/maven2/com/juul/kable/kable-core/"
   },
   {
     "github": "adevone/lagerpeton",


### PR DESCRIPTION
Kable [0.33.0](https://github.com/JuulLabs/kable/releases/tag/0.33.0) changed Kable's Maven coordinates (`core` artifact ID was changed to `kable-core`).