### PR TITLE
Add compose-multiplatform-html-unified

### DIFF
--- a/libraries.json
+++ b/libraries.json
@@ -1258,5 +1258,10 @@
     "github": "fleeksoft/ksoup",
     "category": "Utils",
     "maven": "https://repo1.maven.org/maven2/com/fleeksoft/ksoup/ksoup/"
+  },
+  {
+    "github": "huanshankeji/compose-multiplatform-html-unified",
+    "category": "UI",
+    "maven": "https://repo1.maven.org/maven2/com/huanshankeji/compose-multiplatform-html-unified-material3/"
   }
 ]


### PR DESCRIPTION
This library has multiple Maven modules and I have only linked the most representative one in the JSON `maven` field. If OK, the Maven link can be changed to our organization link <https://repo1.maven.org/maven2/com/huanshankeji>, which also contains other libraries though, or a wildcard link pattern like `https://repo1.maven.org/maven2/com/huanshankeji/compose-multiplatform-html-unified-*/`.