### PR TITLE
MINOR - Add missing '/' to essential-kson library maven URL

### DIFF
--- a/libraries.json
+++ b/libraries.json
@@ -1052,7 +1052,7 @@
   {
     "github": "arkanovicz/essential-kson",
     "category": "Utils",
-    "maven": "https://repo1.maven.org/maven2/com/republicate/kson/essential-kson"
+    "maven": "https://repo1.maven.org/maven2/com/republicate/kson/essential-kson/"
   },
   {
     "github": "chopyourbrain/Kontrol",


### PR DESCRIPTION
The title says it all...